### PR TITLE
feat: add delete and edit functionality to monsterCtrl

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,10 @@ const paths = {
     scripts: ['src/**/*.js', '!src/**/*Spec.js'],
     scriptsNoConfig: ['src/**/*.js', '!src/**/*Spec.js', '!src/config/*.js'],
     tests: 'src/**/*Spec.js',
-    angular: 'node_modules/angular/**/*.min.js',
+    thirdParty: [
+        'node_modules/lodash/index.js',
+        'node_modules/angular/**/*.min.js'
+    ],
     styles: [
         'node_modules/font-awesome/css/font-awesome.min.css'
     ],
@@ -70,8 +73,8 @@ gulp.task('build:copy-html', function () {
                 .pipe(gulp.dest(paths.output));
 });
 
-gulp.task('build:angular', function () {
-    return gulp.src(paths.angular)
+gulp.task('build:third-party', function () {
+    return gulp.src(paths.thirdParty)
                 .pipe(plugins.concat('third-party.js'))
                 .pipe(gulp.dest(paths.output));
 });
@@ -93,8 +96,8 @@ gulp.task('build:less', function () {
                 .pipe(plugins.livereload());
 });
 
-gulp.task('build:third-party', [
-    'build:angular',
+gulp.task('build:external', [
+    'build:third-party',
     'build:styles',
     'build:fonts'
 ]);
@@ -103,10 +106,10 @@ gulp.task('build-local', function (callback) {
     runSequence(
         'clean:dist',
         'build:local-config',
+        'build:external',
         'build:internal',
         'build:copy-html',
         'build:less',
-        'build:third-party',
         callback
     );
 });
@@ -115,10 +118,10 @@ gulp.task('build-prod', function (callback) {
     runSequence(
         'clean:dist',
         'build:prod-config',
+        'build:external',
         'build:internal',
         'build:copy-html',
         'build:less',
-        'build:third-party',
         callback
     );
 });
@@ -150,6 +153,6 @@ gulp.task('listen', ['default'], function () {
     plugins.livereload.listen();
     gulp.watch(paths.scriptsNoConfig, ['default']).on('change', plugins.livereload.changed);
     gulp.watch(paths.less, ['build:less']).on('change', plugins.livereload.changed);
-    gulp.watch(paths.html, ['build:less']).on('change', plugins.livereload.changed);
+    gulp.watch(paths.html, ['default']).on('change', plugins.livereload.changed);
     gulp.watch(paths.tests, ['tests:run']).on('change', plugins.livereload.changed);
 });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function(config) {
     files: [
       'node_modules/angular/angular.min.js',
       'node_modules/angular-mocks/angular-mocks.js',
+      'node_modules/lodash/index.js',
       'src/**/*.js',
       'src/**/*Spec.js'
     ],

--- a/src/index.html
+++ b/src/index.html
@@ -15,20 +15,35 @@
         <main class="monster-container">
             <section class="monster-card-container">
                 <monster-card ng-repeat='monster in monsterCtrl.model.monsters | orderBy:"name"'
-                    monster='monster'>
+                    monster='monster'
+                    delete-monster='monsterCtrl.deleteMonster'
+                    prepare-edit='monsterCtrl.prepareEdit'>
                 </monster-card>
             </section> <!-- monster-card-container -->
-            <aside class="monster-creator">
-                <header class="monster-creator-title">
-                    <div class="monster-creator-title-text">
+            <aside class="monster-window">
+                <header class="monster-window-title">
+                    <div class="monster-window-title-text">
                         Add a new monster here:
-                    </div> <!-- monster-creator-title-text -->
-                </header> <!-- monster-creator-title -->
-                <form class='new-monster-form'>
+                    </div> <!-- monster-window-title-text -->
+                </header> <!-- monster-window-title -->
+                <form class='monster-form'>
                     Enter Name: <input ng-model='monsterCtrl.model.newMonster.name'></input>
                     Enter HP: <input ng-model='monsterCtrl.model.newMonster.hp'></input>
                     <button class='create-monster-button' ng-click='monsterCtrl.createMonster()'>Create!</button>
                 </form> <!-- new-monster-form -->
+                <div class="monster-window" ng-if='monsterCtrl.model.isEditing'>
+                    <header class="monster-window-title">
+                        <div class="monster-window-title-text">
+                            Edit Monster:
+                        </div> <!-- monster-window-title-text -->
+                    </header> <!-- monster-window-title -->
+                    <form class='monster-form'>
+                        Edit Name: <input ng-model='monsterCtrl.model.editMonster.name'></input>
+                        Edit HP: <input ng-model='monsterCtrl.model.editMonster.hp'></input>
+                        <button class='edit-monster-button'
+                                ng-click='monsterCtrl.editMonster(monsterCtrl.model.editMonster)'>Edit</button>
+                    </form>
+                </div> <!-- monster-editor -->
             </aside> <!-- monster-creator -->
         </main> <!-- monster-container -->
     </body>

--- a/src/index.less
+++ b/src/index.less
@@ -39,14 +39,36 @@
                     border-top-left-radius: 4px;
                     border-top-right-radius: 4px;
                     width: 100%;
-                    display: flex;
 
-                    .monster-name {
-                        padding: 5px;
-                        color: white;
-                        font-size: 20px;
-                        font-weight: 300;
-                    } //monster-name
+                    .monster-header-wrapper {
+                        display: flex;
+                        align-items: space-between;
+                        flex-direction: row;
+                        justify-content: center;
+                        .monster-name {
+                            flex: 50;
+                            padding: 5px;
+                            color: white;
+                            font-size: 20px;
+                            font-weight: 300;
+                        } //monster-name
+
+                        .monster-edit {
+                            flex: 1;
+                            padding: 5px;
+                            color: white;
+                            font-size: 20px;
+                            font-weight: 300;
+                        } //monster-edit
+
+                        .monster-delete {
+                            flex: 1;
+                            padding: 5px;
+                            color: white;
+                            font-size: 20px;
+                            font-weight: 300;
+                        } //monster-delete
+                    } //monster-header-wrapper
                 } //monster-header
 
                 .monster-stats {
@@ -62,23 +84,23 @@
             } //monster-card
         } //monster-card-container
 
-        .monster-creator {
+        .monster-window {
             flex: 1;
             margin:15px;
             margin-left: 5px;
             border: 1px solid @ws-gray;
             border-radius: 4px;
-            .monster-creator-title {
+            .monster-window-title {
                 background-color: @ws-gray;
-                .monster-creator-title-text {
+                .monster-window-title-text {
                     padding: 5px;
                     color: white;
                     width: 100%;
-                } //monster-creator-title-text
-            } //monster-creator-title
-            .new-monster-form {
+                } //monster-window-title-text
+            } //monster-window-title
+            .monster-form {
                 padding:10px;
-            } //new-monster-form
+            } //monster-form
         } //monster-creator
     } //monster-container
 } //monster-body

--- a/src/monster/monsterCard.directive.html
+++ b/src/monster/monsterCard.directive.html
@@ -1,6 +1,14 @@
 <details open class="monster-card">
     <summary class="monster-header">
-        <div class="monster-name">{{monster.name}}</div>
+        <div class="monster-header-wrapper">
+            <div class="monster-name">{{monster.name}}</div>
+            <div class="monster-edit">
+                <i class="fa fa-pencil-square-o" ng-click="prepareEdit(monster._id)"></i>
+            </div> <!-- monster-edit -->
+            <div class="monster-delete">
+                <i class="fa fa-trash-o" ng-click="deleteMonster(monster._id)"></i>
+            </div> <!--  monster-delete -->
+        </div> <!-- monster-header-wrapper -->
     </summary> <!-- monster-header -->
     <div class="monster-stats">
         <div class="monster-hp"><i class="fa fa-heart"></i> {{monster.hp}}</div>

--- a/src/monster/monsterCard.js
+++ b/src/monster/monsterCard.js
@@ -10,7 +10,9 @@
             templateUrl: 'monster/monsterCard.directive.html',
             restrict: 'EA',
             scope: {
-                monster: '='
+                monster: '=',
+                deleteMonster: '=',
+                prepareEdit: '='
             }
         };
 

--- a/src/monster/monsterCtrl.js
+++ b/src/monster/monsterCtrl.js
@@ -17,10 +17,19 @@
             newMonster: {
                 name: null,
                 hp: null
-            }
+            },
+            editMonster: {
+                _id: null,
+                name: null,
+                hp: null
+            },
+            isEditing: false
         };
         vm.initialize = initialize;
         vm.createMonster = createMonster;
+        vm.deleteMonster = deleteMonster;
+        vm.editMonster = editMonster;
+        vm.prepareEdit = prepareEdit;
 
         initialize();
 
@@ -44,6 +53,38 @@
                         })
                         .finally(function () {
                             vm.model.newMonster = null;
+                        });
+        }
+
+        function deleteMonster(id) {
+            monsterSvc.removeMonster(id)
+                        .then(function (response) {
+                            _.remove(vm.model.monsters, function(monster) {
+                                return monster._id === id;
+                            });
+                        })
+                        .catch(function (response) {
+                            console.log('Delete error?!');
+                        });
+        }
+
+        function prepareEdit(id) {
+            vm.model.isEditing = true;
+            var toEditMonster = _.find(vm.model.monsters, {'_id': id});
+            _.assign(vm.model.editMonster, toEditMonster);
+        }
+
+        function editMonster(updateMonster) {
+            monsterSvc.updateMonster(updateMonster._id, updateMonster)
+                        .then(function (response) {
+                            _.remove(vm.model.monsters, {'_id': updateMonster._id});
+                            vm.model.monsters.push(response.data);
+                        })
+                        .catch(function (response) {
+                            console.log('Edit error?!');
+                        })
+                        .finally(function() {
+                            vm.model.isEditing = false;
                         });
         }
     }


### PR DESCRIPTION
Create deleteMonster function in monsterCtrl
Add tests for deleteMonster in monsterCtrl
Update unit tests to reflect monsterCtrl functionality
Pass deleteMonster to monsterCard via index.js
Call deleteMonster on monster._id from monsterCard header
Add fa-trash-o icon to header with delete on-click
Recenter garbage can to look better on the card
Add edit icon (to eventually be a button)
Create editMonster() and prepareEdit() functions
Employ editMonster() and prepareEdit() functions in index.html
Add tests for the aforementioned functions
Decorate Monster Editing window and normalize Monster Window LESS
