### PR TITLE
feat: add dice notation as acceptable DpR

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,10 +40,10 @@
   "homepage": "https://github.com/AsmodeusXI/worldshaper#readme",
   "dependencies": {
     "angular": "^1.4.4",
-    "angular-ui-router": "^0.2.17",
+    "angular-ui-router": "^0.3.2",
     "browserify": "^13.1.0",
     "del": "^2.0.2",
-    "dnd-5e-cr-calculator": "^1.1.0",
+    "dnd-5e-cr-calculator": "^2.0.0",
     "font-awesome": "^4.4.0",
     "http-server": "^0.8.0",
     "less": "^2.5.1",

--- a/src/monster/monsterCard.directive.html
+++ b/src/monster/monsterCard.directive.html
@@ -18,7 +18,7 @@
     </div> <!-- monster-stat-block -->
     <div class="monster-stat-block">
       <div class="monster-atk"><i class="fa fa-crosshairs"></i> {{monster.atk}}</div> <!-- monster-atk -->
-      <div class="monster-dpr"><i class="fa fa-gavel"></i> {{monster.dpr}}</div> <!-- monster-dpr -->
+      <div class="monster-dpr"><i class="fa fa-gavel"></i> {{displayRelevantDpr(monster)}}</div> <!-- monster-dpr -->
       <div class="monster-sdc"><i class="fa fa-magic"></i> {{monster.sdc}}</div> <!-- monster-sdc -->
     </div> <!-- monster-stat-block -->
   </div> <!-- monster-stats -->

--- a/src/monster/monsterCard.js
+++ b/src/monster/monsterCard.js
@@ -12,7 +12,8 @@
       scope: {
         monster: '=',
         deleteMonster: '=',
-        prepareEdit: '='
+        prepareEdit: '=',
+        displayRelevantDpr: '='
       }
     };
 


### PR DESCRIPTION
Update dnd-5e-cr-calculator to 2.0.0
Create calculateExpectedCr so that the correct DpR stat is used, preferring dprStr
Create displayRelevantDpr so that the monster cards show the correct DpR stat, preferring dprStr
Add tests that validate use of dprStr